### PR TITLE
fix: `Behavior when concatenating bool-dtype and numeric-dtype arrays is deprecated`

### DIFF
--- a/bktest/__version__.py
+++ b/bktest/__version__.py
@@ -1,6 +1,6 @@
 __title__ = 'bktest'
 __description__ = 'bktest - A simple backtester by CrunchDAO'
-__version__ = '1.1.0'
+__version__ = '1.1.1'
 __author__ = 'Enzo CACERES'
 __author_email__ = 'enzo.caceres@crunchdao.com'
 __url__ = 'https://github.com/crunchdao/backtest'

--- a/bktest/export/dump.py
+++ b/bktest/export/dump.py
@@ -67,7 +67,7 @@ class DumpExporter(Exporter):
 
         common = [
             snapshot.equity,
-            snapshot.ordered,
+            float(snapshot.ordered),
         ]
 
         self.rows.extend([


### PR DESCRIPTION
Full message:

```
/home/jovyan/work/optimizer/.venv/lib/python3.10/site-packages/bktest/export/dump.py:122: FutureWarning: Behavior when concatenating bool-dtype and numeric-dtype arrays is deprecated; in a future version these will cast to object dtype (instead of coercing bools to numeric values). To retain the old behavior, explicitly cast bool-dtype arrays to numeric dtype.
  group = pandas.concat([group, holes])
```